### PR TITLE
Fix broken errorDir: up

### DIFF
--- a/dist/Chart.js
+++ b/dist/Chart.js
@@ -7921,7 +7921,7 @@ module.exports = function(Chart) {
 			}
 
 			//draw lower error bar
-			if (this.errorDir !== "up") {
+			if (vm.direction !== "up") {
 				ctx.beginPath();
 				ctx.moveTo(vm.x, middle);
 				ctx.lineTo(vm.x, bottom);


### PR DESCRIPTION
The `errorDir: up` does not work.

Caused by looking up `direction` from wrong place.